### PR TITLE
Added support for Elastic Search 6

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/persist/HttpPersist.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/persist/HttpPersist.scala
@@ -65,7 +65,7 @@ case class HttpPersist(config: Map[String, Any], metricName: String, timeStamp: 
       val data = JsonUtil.toJson(dataMap)
       // post
       val params = Map[String, Object]()
-      val header = Map[String, Object]()
+      val header = Map[String, Object](("Content-Type","application/json"))
 
       def func(): Boolean = {
         HttpUtil.httpRequest(api, method, params, header, data)


### PR DESCRIPTION
It is necessary to mention the content type in elastic search 6. I was not able to get metrics unless. 