### PR TITLE
Fix livy parmas escape bug.

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/Application.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Application.scala
@@ -39,7 +39,8 @@ object Application extends Loggable {
     }
 
     val envParamFile = args(0)
-    val userParamFile = args(1)
+    // to fix livy bug: character ` will be ignored by livy
+    val userParamFile = args(1).replaceAll("\\\\`", "`")
     val (envFsType, userFsType) = if (args.length > 2) {
       val fsTypes = args(2).trim.split(",")
       if (fsTypes.length == 1) (fsTypes(0).trim, fsTypes(0).trim)


### PR DESCRIPTION
We escape '`' on SparkSubmitJob, but no unescpae when parse json on org.apache.griffin.measure.Application, so it will be encounter parse error when running job.