### PR TITLE
fix a bad practice

### DIFF
--- a/service/src/main/java/org/apache/griffin/core/metric/MetricStoreImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/metric/MetricStoreImpl.java
@@ -81,7 +81,7 @@ public class MetricStoreImpl implements MetricStore {
         this.urlGet = urlBase.concat("/_search?filter_path=hits.hits._source");
         this.urlPost = urlBase.concat("/_bulk");
         this.urlDelete = urlBase.concat("/_delete_by_query");
-        this.indexMetaData = String.format("{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\" } }\n", INDEX, TYPE);
+        this.indexMetaData = String.format("{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\" } }%n", INDEX, TYPE);
         this.mapper = new ObjectMapper();
     }
 


### PR DESCRIPTION
Format string should use %n rather than \n
In format strings, it is generally preferable better to use %n,
which will produce the platform-specific line separator.