### PR TITLE
fix a bad practice, Empty interpolated string

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/context/DataFrameCache.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/context/DataFrameCache.scala
@@ -46,12 +46,12 @@ case class DataFrameCache() extends Loggable {
         trashDataFrame(odf)
         dataFrames += (name -> df)
         df.cache
-        info(s"cache after replace old df")
+        info("cache after replace old df")
       }
       case _ => {
         dataFrames += (name -> df)
         df.cache
-        info(s"cache after replace no old df")
+        info("cache after replace no old df")
       }
     }
   }


### PR DESCRIPTION
String declared as interpolated but has no parameters: scala.StringContext.apply("cache after replace old df").s()