### PR TITLE
fix a bad practice, Empty interpolated string

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/expr/SelectExpr.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/expr/SelectExpr.scala
@@ -57,7 +57,7 @@ trait SelectExpr extends Expr with AliasableExpr {
 }
 
 case class AllFieldsSelectExpr() extends SelectExpr {
-  def desc: String = s".*"
+  def desc: String = ".*"
   def coalesceDesc: String = desc
   def alias: Option[String] = None
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/CompletenessAnalyzer.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/CompletenessAnalyzer.scala
@@ -40,7 +40,7 @@ case class CompletenessAnalyzer(expr: CompletenessClause, sourceName: String) ex
   }
 
   if (selectionPairs.isEmpty) {
-    throw new Exception(s"completeness analyzer error: empty selection")
+    throw new Exception("completeness analyzer error: empty selection")
   }
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/DistinctnessAnalyzer.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/DistinctnessAnalyzer.scala
@@ -41,7 +41,7 @@ case class DistinctnessAnalyzer(expr: DistinctnessClause, sourceName: String) ex
   }
 
   if (selectionPairs.isEmpty) {
-    throw new Exception(s"uniqueness analyzer error: empty selection")
+    throw new Exception("uniqueness analyzer error: empty selection")
   }
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/TimelinessAnalyzer.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/TimelinessAnalyzer.scala
@@ -57,7 +57,7 @@ case class TimelinessAnalyzer(expr: TimelinessClause, sourceName: String) extend
   private val exprs = expr.exprs.map(_.desc).toList
 
   val (btsExpr, etsExprOpt) = exprs match {
-    case Nil => throw new Exception(s"timeliness analyzer error: ts column not set")
+    case Nil => throw new Exception("timeliness analyzer error: ts column not set")
     case btsExpr :: Nil => (btsExpr, None)
     case btsExpr :: etsExpr :: _ => (btsExpr, Some(etsExpr))
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/UniquenessAnalyzer.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/analyzer/UniquenessAnalyzer.scala
@@ -40,7 +40,7 @@ case class UniquenessAnalyzer(expr: UniquenessClause, sourceName: String, target
   }
 
   if (selectionPairs.isEmpty) {
-    throw new Exception(s"uniqueness analyzer error: empty selection")
+    throw new Exception("uniqueness analyzer error: empty selection")
   }
 
 }


### PR DESCRIPTION
String declared as interpolated but has no parameters: scala.StringContext.apply("...").s()