### PR TITLE
fix a bad practice, Empty interpolated string

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClient.scala
@@ -135,7 +135,7 @@ trait StreamingCacheClient extends StreamingOffsetCacheable with WithFanIn[Long]
           df.unpersist
         }
         case _ => {
-          info(s"no data frame to save")
+          info("no data frame to save")
         }
       }
 
@@ -337,7 +337,7 @@ trait StreamingCacheClient extends StreamingOffsetCacheable with WithFanIn[Long]
           }
         }
         case _ => {
-          info(s"no data frame to update")
+          info("no data frame to update")
         }
       }
     }

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClientFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClientFactory.scala
@@ -58,7 +58,7 @@ object StreamingCacheClientFactory extends Loggable {
         Some(dsCache)
       } catch {
         case e: Throwable => {
-          error(s"generate data source cache fails")
+          error("generate data source cache fails")
           None
         }
       }

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/streaming/KafkaStreamingStringDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/streaming/KafkaStreamingStringDataConnector.scala
@@ -61,7 +61,7 @@ case class KafkaStreamingStringDataConnector(@transient sparkSession: SparkSessi
         Some(df)
       } catch {
         case e: Throwable => {
-          error(s"streaming data transform fails")
+          error("streaming data transform fails")
           None
         }
       }

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
@@ -177,7 +177,7 @@ case class StreamingDQApp(allParam: GriffinConfig) extends DQApp {
           OffsetCacheClient.startOffsetCache
 
           val startTime = new Date().getTime
-          appPersist.log(startTime, s"starting process ...")
+          appPersist.log(startTime, "starting process ...")
           val contextId = ContextId(startTime)
 
           // create dq context


### PR DESCRIPTION
String declared as interpolated but has no parameters: scala.StringContext.apply("...").s()