### PR TITLE
GRIFFIN-182 - fix blank flash when routing from job to metric detail

### DIFF
--- a/ui/angular/package.json
+++ b/ui/angular/package.json
@@ -32,7 +32,7 @@
     "font-awesome": "^4.7.0",
     "ng2-bootstrap": "1.6.3",
     "ng2-nouislider": "^1.7.6",
-    "ngx-echarts": "1.2.4",
+    "ngx-echarts": "2.2.0",
     "nouislider": "11.0.3",
     "rxjs": "5.4.2",
     "zone.js": "^0.8.14"

--- a/ui/angular/src/app/app.module.ts
+++ b/ui/angular/src/app/app.module.ts
@@ -23,7 +23,7 @@ import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { DataTableModule} from "angular2-datatable";
 import { TreeModule } from 'angular-tree-component';
 import { BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import { AngularEchartsModule } from 'ngx-echarts';
+import { NgxEchartsModule } from 'ngx-echarts';
 import { MatDatepickerModule, MatNativeDateModule} from '@angular/material';
 import { Location, LocationStrategy, HashLocationStrategy} from '@angular/common';
 import { ToasterModule, ToasterService} from 'angular2-toaster';
@@ -168,7 +168,7 @@ const appRoutes: Routes = [
     ToasterModule,
     FormsModule,
     NouisliderModule,
-    AngularEchartsModule,
+    NgxEchartsModule,
     DataTableModule,
     AngularMultiSelectModule,
     RouterModule.forRoot(

--- a/ui/angular/src/app/health/health.component.ts
+++ b/ui/angular/src/app/health/health.component.ts
@@ -38,9 +38,9 @@ export class HealthComponent implements OnInit {
   mesWithJob: any;
 
   onChartClick($event) {
+    let self = this;
     if ($event.data.name) {
-      this.router.navigate(["/detailed/" + $event.data.name]);
-      window.location.reload();
+      self.router.navigate(["/detailed/" + $event.data.name]);
     }
   }
 
@@ -86,6 +86,7 @@ export class HealthComponent implements OnInit {
           metricId++;
         }
       }
+      item.children = item.children.sort(function(a,b) {return (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0);} );
       result.push(item);
       sysId++;
     }


### PR DESCRIPTION
GRIFFIN-182 - fix blank flash when routing from job to metric detail

ISSUE:
currently, when navigating from ```health``` jobs to job-metric detail page, it will reload the health page causing blank flash