### PR TITLE
Fix UI bugs 

### DIFF
--- a/ui/angular/package.json
+++ b/ui/angular/package.json
@@ -32,7 +32,7 @@
     "font-awesome": "^4.7.0",
     "ng2-bootstrap": "1.6.3",
     "ng2-nouislider": "^1.7.6",
-    "ngx-echarts": "2.2.0",
+    "ngx-echarts": "2.3.1",
     "nouislider": "11.0.3",
     "rxjs": "5.4.2",
     "zone.js": "^0.8.14"

--- a/ui/angular/src/app/job/job.component.ts
+++ b/ui/angular/src/app/job/job.component.ts
@@ -189,6 +189,7 @@ export class JobComponent implements OnInit {
       let trans = Object.keys(data).map(function (index) {
         let job = self.swapJson(data[index]);
         job.showDetail = false;
+        job.jobState.previousFireTime = job.jobState.previousFireTime < 0?'':job.jobState.previousFireTime;
         job.action = (job.jobState.toStart === true) ? 'START' : 'STOP';
         return job;
       });

--- a/ui/angular/src/app/measure/create-measure/ac/ac.component.ts
+++ b/ui/angular/src/app/measure/create-measure/ac/ac.component.ts
@@ -90,7 +90,7 @@ export class AcComponent implements OnInit, AfterViewChecked {
   currentDBstr: string;
   srcconfig = {
     where: "",
-    timezone: "",
+    timezone: "UTC(WET,GMT)",
     num: 1,
     timetype: "day",
     needpath: false,
@@ -98,7 +98,7 @@ export class AcComponent implements OnInit, AfterViewChecked {
   };
   tgtconfig = {
     where: "",
-    timezone: "",
+    timezone: "UTC(WET,GMT)",
     num: 1,
     timetype: "day",
     needpath: false,
@@ -691,6 +691,8 @@ export class AcComponent implements OnInit, AfterViewChecked {
     });
     this.src_size = "1day";
     this.tgt_size = "1day";
+    this.src_timezone = this.srcconfig.timezone;
+    this.tgt_timezone = this.tgtconfig.timezone;
   }
 
   ngAfterViewChecked() {

--- a/ui/angular/src/app/measure/create-measure/ac/ac.component.ts
+++ b/ui/angular/src/app/measure/create-measure/ac/ac.component.ts
@@ -90,7 +90,7 @@ export class AcComponent implements OnInit, AfterViewChecked {
   currentDBstr: string;
   srcconfig = {
     where: "",
-    timezone: "UTC(WET,GMT)",
+    timezone: "",
     num: 1,
     timetype: "day",
     needpath: false,
@@ -98,7 +98,7 @@ export class AcComponent implements OnInit, AfterViewChecked {
   };
   tgtconfig = {
     where: "",
-    timezone: "UTC(WET,GMT)",
+    timezone: "",
     num: 1,
     timetype: "day",
     needpath: false,

--- a/ui/angular/src/app/measure/create-measure/configuration/configuration.component.ts
+++ b/ui/angular/src/app/measure/create-measure/configuration/configuration.component.ts
@@ -48,7 +48,7 @@ export class ConfigurationComponent implements OnInit {
   selectedType: string;
   configuration = {
     where: "",
-    timezone: "",
+    timezone: "UTC(WET,GMT)",
     num: 1,
     timetype: "day",
     needpath: false,

--- a/ui/angular/src/app/measure/create-measure/configuration/configuration.component.ts
+++ b/ui/angular/src/app/measure/create-measure/configuration/configuration.component.ts
@@ -48,7 +48,7 @@ export class ConfigurationComponent implements OnInit {
   selectedType: string;
   configuration = {
     where: "",
-    timezone: "UTC(WET,GMT)",
+    timezone: "",
     num: 1,
     timetype: "day",
     needpath: false,

--- a/ui/angular/src/app/measure/create-measure/create-measure.component.css
+++ b/ui/angular/src/app/measure/create-measure/create-measure.component.css
@@ -121,3 +121,13 @@ div.tree > treenode > div > .node-wrapper > treenodeexpander > .toggle-children-
 .panel-footer {
   background-color: #3c3c3c;
 }
+
+
+a.adisabled {
+  cursor: not-allowed;
+  opacity: .65;
+}
+
+a.adisabled:hover { text-decoration: none; }
+a.adisabled:focus { text-decoration: none; }
+a.adisabled:active { text-decoration: none; }

--- a/ui/angular/src/app/measure/create-measure/pr/confirmModal/confirmModal.component.html
+++ b/ui/angular/src/app/measure/create-measure/pr/confirmModal/confirmModal.component.html
@@ -70,11 +70,11 @@ under the License.
                   {{step3.size}}
                 </div>
               </div>
-              <div class="row">
+              <div class="row" *ngIf="step3.timezone">
                 <label class="col-md-4 col-lg-4 col-sm-4">
                   Source Time Zone:
                 </label>
-                <div class="col-md-8 col-lg-8 col-sm-8">
+                <div class="col-md-8 col-lg-8 col-sm-8" *ngIf="step3.timezone">
                   {{step3.timezone}}
                 </div>
               </div>

--- a/ui/angular/src/app/measure/create-measure/pr/pr.component.ts
+++ b/ui/angular/src/app/measure/create-measure/pr/pr.component.ts
@@ -46,13 +46,13 @@ export class ProfilingStep2 {
 export class ProfilingStep3 {
   config: object = {
     where: "",
-    timezone: "UTC(WET,GMT)",
+    timezone: "",
     num: 1,
     timetype: "day",
     needpath: false,
     path: ""
   };
-  timezone: string = "UTC(WET,GMT)";
+  timezone: string = "";
   where: string = "";
   size: string = "1day";
   needpath: boolean = false;
@@ -178,7 +178,7 @@ export class PrComponent implements AfterViewChecked, OnInit {
         if (originrule == "Enum Detection Top5 Count") {
 
           enmvalue = this.transferRule(originrule, selected);
-          grpname = `${selected.name}_grp`;
+          grpname = `${selected.name}_top5count`;
           this.transenumrule.push(enmvalue);
           this.pushEnmRule(enmvalue, grpname);
 
@@ -243,7 +243,7 @@ export class PrComponent implements AfterViewChecked, OnInit {
       "out": [
         {
           "type": "metric",
-          "name": grpname+"_group",
+          "name": grpname.split("_")[0]=="id"?"id":grpname,
           "flatten": "array"
         }
       ]

--- a/ui/angular/src/app/measure/create-measure/pr/pr.component.ts
+++ b/ui/angular/src/app/measure/create-measure/pr/pr.component.ts
@@ -239,10 +239,14 @@ export class PrComponent implements AfterViewChecked, OnInit {
       "dsl.type": "griffin-dsl",
       "dq.type": "PROFILING",
       rule: rule,
-      name: grpname,
-      metric: {
-        "collect.type": "array"
-      }
+      "out.dataframe.name": grpname,
+      "out": [
+        {
+          "type": "metric",
+          "name": grpname+"_group",
+          "flatten": "array"
+        }
+      ]
     });
   }
 
@@ -251,7 +255,7 @@ export class PrComponent implements AfterViewChecked, OnInit {
       "dsl.type": "griffin-dsl",
       "dq.type": "PROFILING",
       rule: rule,
-      name: nullname
+      "out.dataframe.name": nullname
     });
   }
 
@@ -260,7 +264,7 @@ export class PrComponent implements AfterViewChecked, OnInit {
       "dsl.type": "griffin-dsl",
       "dq.type": "PROFILING",
       rule: rule,
-      name: nullname
+      "out.dataframe.name": nullname
     });
   }
 
@@ -305,11 +309,11 @@ export class PrComponent implements AfterViewChecked, OnInit {
         );
       case "Regular Expression Detection Count":
         return (
-          `count(source.${col.name} RLIKE '${col.regex}') AS \`${col.name}_regexcount\``
+          `count(source.${col.name}) AS \`${col.name}_regexcount\` WHERE source.${col.name} RLIKE '^[0-9]{4}$'`
         );
       case "Enum Detection Top5 Count":
         return (
-          `source.${col.name}, ${col.name}, count(*) AS count GROUP BY source.${col.name} ORDER BY count DESC LIMIT 5`
+          `source.${col.name} AS ${col.name}, count(*) AS count GROUP BY source.${col.name} ORDER BY count DESC LIMIT 5`
         );
     }
   }

--- a/ui/angular/src/app/measure/create-measure/pr/pr.component.ts
+++ b/ui/angular/src/app/measure/create-measure/pr/pr.component.ts
@@ -243,7 +243,7 @@ export class PrComponent implements AfterViewChecked, OnInit {
       "out": [
         {
           "type": "metric",
-          "name": grpname.split("_")[0]=="id"?"id":grpname,
+          "name": grpname,
           "flatten": "array"
         }
       ]

--- a/ui/angular/src/app/metric/detail-metric/detail-metric.component.css
+++ b/ui/angular/src/app/metric/detail-metric/detail-metric.component.css
@@ -97,3 +97,12 @@ under the License.
 .clone tfoot {
   background: transparent;
 }
+
+a.adisabled {
+  cursor: not-allowed;
+  opacity: .65;
+}
+
+a.adisabled:hover { text-decoration: none; }
+a.adisabled:focus { text-decoration: none; }
+a.adisabled:active { text-decoration: none; }

--- a/ui/angular/src/app/metric/detail-metric/detail-metric.component.html
+++ b/ui/angular/src/app/metric/detail-metric/detail-metric.component.html
@@ -77,16 +77,24 @@ under the License.
         <div class="container-fluid" id="dowloadContent" style="overflow:auto;">
           <tr>
             <td colspan="7" style="padding:20px 30px 10px 30px;">
-              <table class="table table-striped" [mfData]="missRecordList" #mf2="mfDataTable" [mfRowsOnPage]="10">
+              <table class="table table-striped" style="border-spacing: 15px;" [mfData]="missRecordList" #mf2="mfDataTable" [mfRowsOnPage]="10">
 
                 <tbody>
                 <tr *ngIf="!missRecordList">
                   <td colspan="7" style="text-align:center">No content.</td>
                 </tr>
-                <tr *ngFor="let item of mf2.data">
+                <!-- <tr *ngFor="let item of mf2.data">
                   <td style="background-color:black;"><a (click)="downloadSample(item)">{{item.tmst}} {{item.tmst |
                     date: 'yyyy/MM/dd HH:mm:ss'}}</a></td>
-                </tr>
+                </tr> -->
+                <div *ngFor="let item of mf2.data; let isEven = even;let i = index;let isLast= last">
+                 <tr *ngIf="isEven && !isLast">
+                   <td style="background-color:black; cursor: pointer;" nowrap><a [ngClass]="{'adisabled': !isDownloadClickDisabled}" (click)="downloadSample(item)" style="margin: 15px 15px 15px 15px;">{{mf2.data[i].tmst}} {{mf2.data[i].tmst |
+                     date: 'yyyy/MM/dd HH:mm:ss'}}</a></td>
+                   <td style="background-color:black; cursor: pointer;" nowrap><a ng-class="{'adisabled': !isDownloadClickDisabled}" (click)="downloadSample(item)">{{mf2.data[i].tmst}} {{mf2.data[i+1].tmst |
+                     date: 'yyyy/MM/dd HH:mm:ss'}}</a></td>
+                   </tr>
+                 </div>
                 </tbody>
                 <tfoot>
                 <tr>

--- a/ui/angular/src/app/metric/detail-metric/detail-metric.component.ts
+++ b/ui/angular/src/app/metric/detail-metric/detail-metric.component.ts
@@ -128,7 +128,7 @@ export class DetailMetricComponent implements AfterViewChecked, OnInit {
                   records += record;
                 }
                 delete item.value[key];
-                key = key + ' (' + keysplit[0] + ', count)';
+                key = key + ' (' + keysplit[0].split("_")[0] + ', count)';
                 item.value[key] = records;
                 // var sortable = [];
                 // for(let i in item.value[key]){

--- a/ui/angular/src/app/metric/detail-metric/detail-metric.component.ts
+++ b/ui/angular/src/app/metric/detail-metric/detail-metric.component.ts
@@ -68,7 +68,7 @@ export class DetailMetricComponent implements AfterViewChecked, OnInit {
   missRecordList = [];
   public visible = false;
   public visibleAnimate = false;
-
+  isDownloadClickDisabled = true;
 
   ngOnInit() {
     this.currentJob = this.route.snapshot.paramMap.get("name");
@@ -194,6 +194,7 @@ export class DetailMetricComponent implements AfterViewChecked, OnInit {
   }
 
   downloadSample(row) {
+    this.isDownloadClickDisabled = !this.isDownloadClickDisabled;
     let urlDownload = this.serviceService.config.uri.missRecordDownload + "?jobName=" + row.name + "&ts=" + row.tmst;
     this.http
       .get(urlDownload,
@@ -205,6 +206,7 @@ export class DetailMetricComponent implements AfterViewChecked, OnInit {
         };
       })
       .subscribe(res => {
+        this.isDownloadClickDisabled = !this.isDownloadClickDisabled;
         console.log('start download:', res);
         var url = window.URL.createObjectURL(res.data);
         var a = document.createElement('a');

--- a/ui/angular/src/app/metric/detail-metric/detail-metric.component.ts
+++ b/ui/angular/src/app/metric/detail-metric/detail-metric.component.ts
@@ -130,23 +130,6 @@ export class DetailMetricComponent implements AfterViewChecked, OnInit {
                 delete item.value[key];
                 key = key + ' (' + keysplit[0].split("_")[0] + ', count)';
                 item.value[key] = records;
-                // var sortable = [];
-                // for(let i in item.value[key]){
-                //   for(let category in item.value[key][i]){
-                //     if(category != "count"){
-                //       let name = category + ':' + item.value[key][i][category];
-                //       sortable.push([name, item.value[key][i].count]);
-                //       sortable.sort(function(a, b) {
-                //         return b[1] - a[1];
-                //       });
-                //     }
-                //   }
-                // }
-                // for(let i=0;i<5;i++){
-                //   let grpname = sortable[i][0];
-                //   item.value[grpname] = sortable[i][1];
-                // }
-                // delete item.value[key];
               }
             }
           }


### PR DESCRIPTION
1. In profiling, when selecting rule on UI, for "Enum detection Top5 count", it generates rule like:
	{
	    "rule": "source.desc, desc, count(*) AS count GROUP BY source.desc ORDER BY count DESC LIMIT 5",
	    "dsl.type": "griffin-dsl",
	    "dq.type": "PROFILING"
	}
Actually, we need it to be like:
	{
	    "rule": "source.desc AS desc, count(*) AS count GROUP BY source.desc ORDER BY count DESC LIMIT 5",
	    "dsl.type": "griffin-dsl",
	    "dq.type": "PROFILING",
	    "out": [
	    	{
	            "type": "metric",
	            "name": "desc_group",
	            "flatten": "array"
	        }
	    ]
	}
To flatten the group by metric as an array, and naming it as "${the group column name}_group". Then the metric will be like:
	{"name":"prof_job","tmst":1534768500000,"value":{"desc_group":[{"desc": "aaa", "count": 3}, {"desc": "bbb", "count": 5}]}}

Please notice that there're 2 mistakes in current enum rule, one is the "rule" content, the other one is the lack of "out" field.

2. There's a bug in Dashboard page, when refreshing, it works good, and a metric chart is painted. But after select the measure drop-down box, the chart size is collapsed into a line, which is terrible.

3. In "partition configuration" pages of creating accuracy measure, the item "Time Zone" is blank by default, but in the same page of creating profiling measure, the item "Time Zone" has a default value, which should act the same as the accuracy measure creation page.

4. In "Select Models" page of creating profiling measure, when you select "Regular Expression Detection Count" as a rule for a string column, there will be a text box below, for regular expression. I think the UI is not bad so far.
However, it doesn't work in a right way. The rule it generates is like:
	{
        "rule": "count(source.desc RLIKE '^[0-9]{4}$') AS `desc_regexcount`",
        "dsl.type": "griffin-dsl",
        "dq.type": "PROFILING"
    }
After test, it returns total count of the column, which means the statement "RLIKE" doesn't work. We need to change it like this:
	{
        "rule": "count(source.desc) AS `desc_regexcount` WHERE source.desc RLIKE '^[0-9]{4}$'",
        "dsl.type": "griffin-dsl",
        "dq.type": "PROFILING"
    }
I've tested the latter, it works.

5. For "Download Miss Sample" page, the item list seems a litte strange, it would be better to list them in a table and hover with a hand pointer rather than a text cursor. Besides, sometimes it's slow for the downloading, I think it's better to tell user to wait after a click.