### PR TITLE
Fix rest api bug in service component

### DIFF
--- a/service/src/main/java/org/apache/griffin/core/info/GriffinInfoController.java
+++ b/service/src/main/java/org/apache/griffin/core/info/GriffinInfoController.java
@@ -29,6 +29,6 @@ public class GriffinInfoController {
 
     @RequestMapping(value = "/version", method = RequestMethod.GET)
     public String greeting() {
-        return "0.2.0";
+        return "0.3.0";
     }
 }

--- a/service/src/test/java/org/apache/griffin/core/info/GriffinInfoControllerTest.java
+++ b/service/src/test/java/org/apache/griffin/core/info/GriffinInfoControllerTest.java
@@ -43,6 +43,6 @@ public class GriffinInfoControllerTest {
     public void testGreeting() throws Exception {
         mockMvc.perform(get(URLHelper.API_VERSION_PATH + "/version"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", is("0.2.0")));
+                .andExpect(jsonPath("$", is("0.3.0")));
     }
 }


### PR DESCRIPTION
GET /api/v1/version returns mistaken release version 0.2.0 instead of 0.3.0