### PR TITLE
Make Rule table MySQL-compatible

### DIFF
--- a/service/src/main/java/org/apache/griffin/core/measure/entity/Rule.java
+++ b/service/src/main/java/org/apache/griffin/core/measure/entity/Rule.java
@@ -78,6 +78,7 @@ public class Rule extends AbstractAuditableEntity {
     private List<Map<String, Object>> outList;
 
     @JsonIgnore
+    @Column(name = "\"out\"")
     private String out;
 
     @JsonProperty("dsl.type")


### PR DESCRIPTION
OUT is reserved word in MySQL, so it should be quoted in queries.