### PR TITLE
GRIFFIN-198 Fix caching of incomplete results in HiveMetaStoreService

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ node_js:
 install:
   - npm install -g bower
 
-script: mvn clean verify -q
+script: travis_wait mvn clean verify -q

--- a/service/src/main/java/org/apache/griffin/core/metastore/hive/HiveMetaStoreService.java
+++ b/service/src/main/java/org/apache/griffin/core/metastore/hive/HiveMetaStoreService.java
@@ -35,4 +35,6 @@ public interface HiveMetaStoreService {
     Map<String, List<Table>> getAllTable();
 
     Table getTable(String dbName, String tableName);
+
+    void evictHiveCache();
 }

--- a/service/src/main/java/org/apache/griffin/core/metastore/hive/HiveMetaStoreServiceImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/metastore/hive/HiveMetaStoreServiceImpl.java
@@ -69,6 +69,7 @@ public class HiveMetaStoreServiceImpl implements HiveMetaStoreService {
         } catch (Exception e) {
             reconnect();
             LOGGER.error("Can not get databases : {}", e);
+            throw new RuntimeException(e);
         }
         return results;
     }
@@ -88,6 +89,7 @@ public class HiveMetaStoreServiceImpl implements HiveMetaStoreService {
         } catch (Exception e) {
             reconnect();
             LOGGER.error("Exception fetching tables info: {}", e);
+            throw new RuntimeException(e);
         }
         return results;
     }
@@ -116,6 +118,7 @@ public class HiveMetaStoreServiceImpl implements HiveMetaStoreService {
             return results;
         }
         for (String db : dbs) {
+            // TODO: getAllTable() is not reusing caches of getAllTable(db) and vise versa
             results.put(db, getTables(db));
         }
         return results;
@@ -137,6 +140,7 @@ public class HiveMetaStoreServiceImpl implements HiveMetaStoreService {
             reconnect();
             LOGGER.error("Exception fetching table info : {}. {}", tableName,
                     e);
+            throw new RuntimeException(e);
         }
         return result;
     }
@@ -172,6 +176,7 @@ public class HiveMetaStoreServiceImpl implements HiveMetaStoreService {
         } catch (Exception e) {
             reconnect();
             LOGGER.error("Exception fetching tables info: {}", e);
+            throw new RuntimeException(e);
         }
         return allTables;
     }


### PR DESCRIPTION
Avoiding polluting cache with empty or null values.
Test caching behavior of HiveMetaStoreServiceImpl.
Verified that cache population in evictHiveCache() is not happening, added unittest.

This is only partial fix, getAllTable() calls still can return and cache incomplete results.