### PR TITLE
Increase build silence timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,8 @@ node_js:
 install:
   - npm install -g bower
 
-script: travis_wait mvn clean verify -q
+script: travis_wait 30 mvn clean verify -q
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
According to experiment, resolving dependencies takes longer
than default build timeout of 20 minutes. Increasing to 30.

[Experiment](https://travis-ci.org/apache/incubator-griffin/builds/435326777) shown that sometimes it takes more than 20 minutes to download all the dependencies and start executing tests. In that particular experiment it took 22 minutes in order to get to test execution.