### PR TITLE
Fix timeout failure in travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ scala:
   - 2.10.6
 node_js:
   - "6"
+git:
+  quiet: true
+cache:
+  directories:
+  - $HOME/.m2
 
 install:
   - npm install -g bower


### PR DESCRIPTION
Build times out because no output was received.

'travis_wait mvn clean verify -q' will spawn a process to deal with mvn task
-q,--quiet     Quiet output - only show errors

-q probably leads no output caught by travis, so timeout failure happens

refer to:
https://docs.travis-ci.com/user/common-build-problems/#limitations-of-travis_wait