### PR TITLE
Support "cache" field on rules in service module

### DIFF
--- a/griffin-doc/measure/measure-configuration-guide.md
+++ b/griffin-doc/measure/measure-configuration-guide.md
@@ -234,6 +234,7 @@ Above lists DQ job configure parameters.
     * source: name of data source to measure timeliness.
     * latency: the latency column name in metric, optional.
     * threshold: optional, if set as a time string like "1h", the items with latency more than 1 hour will be record.
+- **cache**: Cache output dataframe. Optional, valid only for "spark-sql" and "df-ops" mode. Defaults to `false` if not specified.
 - **out**: List of output sinks for the job.
   + Metric output.
     * type: "metric"

--- a/service/src/main/java/org/apache/griffin/core/measure/entity/Rule.java
+++ b/service/src/main/java/org/apache/griffin/core/measure/entity/Rule.java
@@ -81,6 +81,9 @@ public class Rule extends AbstractAuditableEntity {
     @Column(name = "\"out\"")
     private String out;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean cache;
+
     @JsonProperty("dsl.type")
     public String getDslType() {
         return dslType;
@@ -157,6 +160,14 @@ public class Rule extends AbstractAuditableEntity {
 
     private void setOut(String out) {
         this.out = out;
+    }
+
+    public Boolean getCache() {
+        return cache;
+    }
+
+    public void setCache(Boolean cache) {
+        this.cache = cache;
     }
 
     @PrePersist


### PR DESCRIPTION
Measure module exposes "cache" flag on rules, but it's not possible to store and schedule such a job in service module.