### PR TITLE
[GRIFFIN-208] log exception details when it makes sense

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/Application.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Application.scala
@@ -85,9 +85,11 @@ object Application extends Loggable {
     }
 
     // dq app run
-    dqApp.run match {
-      case Success(_) =>
-        info("process run success")
+    val success = dqApp.run match {
+      case Success(result) =>
+        info("process run result: " + (if (result) "success" else "failed"))
+        result
+
       case Failure(ex) =>
         error(s"process run error: ${ex.getMessage}", ex)
 
@@ -110,6 +112,10 @@ object Application extends Loggable {
     }
 
     shutdown
+
+    if (!success) {
+      sys.exit(-5)
+    }
   }
 
   private def readParamFile[T <: Param](file: String)(implicit m : ClassTag[T]): Try[T] = {

--- a/measure/src/main/scala/org/apache/griffin/measure/Application.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Application.scala
@@ -51,13 +51,13 @@ object Application extends Loggable {
     val envParam = readParamFile[EnvConfig](envParamFile) match {
       case Success(p) => p
       case Failure(ex) =>
-        error(ex.getMessage)
+        error(ex.getMessage, ex)
         sys.exit(-2)
     }
     val dqParam = readParamFile[DQConfig](dqParamFile) match {
       case Success(p) => p
       case Failure(ex) =>
-        error(ex.getMessage)
+        error(ex.getMessage, ex)
         sys.exit(-2)
     }
     val allParam: GriffinConfig = GriffinConfig(envParam, dqParam)
@@ -79,7 +79,7 @@ object Application extends Loggable {
       case Success(_) =>
         info("process init success")
       case Failure(ex) =>
-        error(s"process init error: ${ex.getMessage}")
+        error(s"process init error: ${ex.getMessage}", ex)
         shutdown
         sys.exit(-5)
     }
@@ -89,7 +89,7 @@ object Application extends Loggable {
       case Success(_) =>
         info("process run success")
       case Failure(ex) =>
-        error(s"process run error: ${ex.getMessage}")
+        error(s"process run error: ${ex.getMessage}", ex)
 
         if (dqApp.retryable) {
           throw ex
@@ -104,7 +104,7 @@ object Application extends Loggable {
       case Success(_) =>
         info("process end success")
       case Failure(ex) =>
-        error(s"process end error: ${ex.getMessage}")
+        error(s"process end error: ${ex.getMessage}", ex)
         shutdown
         sys.exit(-5)
     }

--- a/measure/src/main/scala/org/apache/griffin/measure/Loggable.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Loggable.scala
@@ -36,8 +36,16 @@ trait Loggable {
     logger.warn(msg)
   }
 
+  protected def warn(msg: String, e: Throwable): Unit = {
+    logger.warn(msg, e)
+  }
+
   protected def error(msg: String): Unit = {
     logger.error(msg)
+  }
+
+  protected def error(msg: String, e: Throwable): Unit = {
+    logger.error(msg, e)
   }
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/DataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/DataConnector.scala
@@ -92,7 +92,7 @@ trait DataConnector extends Loggable with Serializable {
 
     } catch {
       case e: Throwable =>
-        error(s"pre-process of data connector [${id}] error: ${e.getMessage}")
+        error(s"pre-process of data connector [${id}] error: ${e.getMessage}", e)
         None
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/AvroBatchDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/AvroBatchDataConnector.scala
@@ -60,7 +60,7 @@ case class AvroBatchDataConnector(@transient sparkSession: SparkSession,
       preDfOpt
     } catch {
       case e: Throwable =>
-        error(s"load avro file ${concreteFileFullPath} fails")
+        error(s"load avro file ${concreteFileFullPath} fails", e)
         None
     }
     val tmsts = readTmst(ms)

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/HiveBatchDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/HiveBatchDataConnector.scala
@@ -56,7 +56,7 @@ case class HiveBatchDataConnector(@transient sparkSession: SparkSession,
       preDfOpt
     } catch {
       case e: Throwable =>
-        error(s"load hive table ${concreteTableName} fails: ${e.getMessage}")
+        error(s"load hive table ${concreteTableName} fails: ${e.getMessage}", e)
         None
     }
     val tmsts = readTmst(ms)

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/TextDirBatchDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/TextDirBatchDataConnector.scala
@@ -70,7 +70,7 @@ case class TextDirBatchDataConnector(@transient sparkSession: SparkSession,
       }
     } catch {
       case e: Throwable =>
-        error(s"load text dir ${dirPath} fails: ${e.getMessage}")
+        error(s"load text dir ${dirPath} fails: ${e.getMessage}", e)
         None
     }
     val tmsts = readTmst(ms)

--- a/measure/src/main/scala/org/apache/griffin/measure/job/DQJob.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/job/DQJob.scala
@@ -23,6 +23,9 @@ import org.apache.griffin.measure.step.DQStep
 
 case class DQJob(dqSteps: Seq[DQStep]) extends Serializable {
 
+  /**
+    * @return execution success
+    */
   def execute(context: DQContext): Boolean = {
     dqSteps.foldLeft(true) { (ret, dqStep) =>
       ret && dqStep.execute(context)

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/DQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/DQApp.scala
@@ -34,7 +34,10 @@ trait DQApp extends Loggable with Serializable {
 
   def init: Try[_]
 
-  def run: Try[_]
+  /**
+    * @return execution success
+    */
+  def run: Try[Boolean]
 
   def close: Try[_]
 

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
@@ -64,7 +64,7 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
     GriffinUDFAgent.register(sqlContext)
   }
 
-  def run: Try[_] = Try {
+  def run: Try[Boolean] = Try {
     // start time
     val startTime = new Date().getTime
 
@@ -88,7 +88,7 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
     val dqJob = DQJobBuilder.buildDQJob(dqContext, dqParam.getEvaluateRule)
 
     // dq job execute
-    dqJob.execute(dqContext)
+    val result = dqJob.execute(dqContext)
 
     // end time
     val endTime = new Date().getTime
@@ -99,6 +99,8 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
 
     // finish
     dqContext.getSink().finish()
+
+    result
   }
 
   def close: Try[_] = Try {

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
@@ -77,7 +77,7 @@ case class StreamingDQApp(allParam: GriffinConfig) extends DQApp {
     GriffinUDFAgent.register(sqlContext)
   }
 
-  def run: Try[_] = Try {
+  def run: Try[Boolean] = Try {
 
     // streaming context
     val ssc = StreamingContext.getOrCreate(sparkParam.getCpDir, () => {
@@ -127,6 +127,7 @@ case class StreamingDQApp(allParam: GriffinConfig) extends DQApp {
     // finish
     globalContext.getSink().finish()
 
+    true
   }
 
   def close: Try[_] = Try {

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/ElasticSearchSink.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/ElasticSearchSink.scala
@@ -69,7 +69,7 @@ case class ElasticSearchSink(config: Map[String, Any], metricName: String,
       if (block) SinkTaskRunner.addBlockTask(func _, retry, connectionTimeout)
       else SinkTaskRunner.addNonBlockTask(func _, retry)
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
 
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/HdfsSink.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/HdfsSink.scala
@@ -81,7 +81,7 @@ case class HdfsSink(config: Map[String, Any], metricName: String, timeStamp: Lon
     try {
       HdfsUtil.writeContent(StartFile, msg)
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 
@@ -89,7 +89,7 @@ case class HdfsSink(config: Map[String, Any], metricName: String, timeStamp: Lon
     try {
       HdfsUtil.createEmptyFile(FinishFile)
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 
@@ -98,7 +98,7 @@ case class HdfsSink(config: Map[String, Any], metricName: String, timeStamp: Lon
       val logStr = logWrap(rt, msg)
       HdfsUtil.appendContent(LogFile, logStr)
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 
@@ -142,7 +142,7 @@ case class HdfsSink(config: Map[String, Any], metricName: String, timeStamp: Lon
         }
       }
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 
@@ -170,7 +170,7 @@ case class HdfsSink(config: Map[String, Any], metricName: String, timeStamp: Lon
         }
       }
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 
@@ -179,7 +179,7 @@ case class HdfsSink(config: Map[String, Any], metricName: String, timeStamp: Lon
       val json = JsonUtil.toJson(metrics)
       sinkRecords2Hdfs(MetricsFile, json :: Nil)
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 
@@ -188,7 +188,7 @@ case class HdfsSink(config: Map[String, Any], metricName: String, timeStamp: Lon
       val recStr = records.mkString("\n")
       HdfsUtil.writeContent(hdfsPath, recStr)
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/MongoSink.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/MongoSink.scala
@@ -77,7 +77,7 @@ case class MongoSink(config: Map[String, Any], metricName: String,
       if (block) SinkTaskRunner.addBlockTask(func _, retry, overTime)
       else SinkTaskRunner.addNonBlockTask(func _, retry)
     } catch {
-      case e: Throwable => error(e.getMessage)
+      case e: Throwable => error(e.getMessage, e)
     }
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/MultiSinks.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/MultiSinks.scala
@@ -45,7 +45,7 @@ case class MultiSinks(sinks: Iterable[Sink]) extends Sink {
       try {
         sink.log(rt, msg)
       } catch {
-        case e: Throwable => error(s"log error: ${e.getMessage}")
+        case e: Throwable => error(s"log error: ${e.getMessage}", e)
       }
     }
   }
@@ -55,7 +55,7 @@ case class MultiSinks(sinks: Iterable[Sink]) extends Sink {
       try {
         sink.sinkRecords(records, name)
       } catch {
-        case e: Throwable => error(s"sink records error: ${e.getMessage}")
+        case e: Throwable => error(s"sink records error: ${e.getMessage}", e)
       }
     }
   }
@@ -64,7 +64,7 @@ case class MultiSinks(sinks: Iterable[Sink]) extends Sink {
       try {
         sink.sinkRecords(records, name)
       } catch {
-        case e: Throwable => error(s"sink records error: ${e.getMessage}")
+        case e: Throwable => error(s"sink records error: ${e.getMessage}", e)
       }
     }
   }
@@ -73,7 +73,7 @@ case class MultiSinks(sinks: Iterable[Sink]) extends Sink {
       try {
         sink.sinkMetrics(metrics)
       } catch {
-        case e: Throwable => error(s"sink metrics error: ${e.getMessage}")
+        case e: Throwable => error(s"sink metrics error: ${e.getMessage}", e)
       }
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/SinkTaskRunner.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/SinkTaskRunner.scala
@@ -64,7 +64,7 @@ object SinkTaskRunner extends Loggable {
           info(s"task ${t} retry [ rest retry count: ${nextRetry} ]")
           nonBlockExecute(func, nextRetry)
         } else {
-          error(s"task fails: task ${t} retry ends but fails")
+          error(s"task fails: task ${t} retry ends but fails", e)
         }
     }
   }
@@ -86,7 +86,7 @@ object SinkTaskRunner extends Loggable {
           info(s"task ${t} retry [ rest retry count: ${nextRetry} ]")
           blockExecute(func, nextRetry, waitDuration)
         } else {
-          error(s"task fails: task ${t} retry ends but fails")
+          error(s"task fails: task ${t} retry ends but fails", e)
         }
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/DQStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/DQStep.scala
@@ -25,6 +25,9 @@ trait DQStep extends Loggable {
 
   val name: String
 
+  /**
+    * @return execution success
+    */
   def execute(context: DQContext): Boolean
 
   def getNames(): Seq[String] = name :: Nil

--- a/measure/src/main/scala/org/apache/griffin/measure/step/SeqDQStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/SeqDQStep.scala
@@ -29,6 +29,9 @@ case class SeqDQStep(dqSteps: Seq[DQStep]) extends DQStep {
   val rule: String = ""
   val details: Map[String, Any] = Map()
 
+  /**
+    * @return execution success
+    */
   def execute(context: DQContext): Boolean = {
     dqSteps.foldLeft(true) { (ret, dqStep) =>
       ret && dqStep.execute(context)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/GriffinDslDQStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/GriffinDslDQStepBuilder.scala
@@ -50,7 +50,7 @@ case class GriffinDslDQStepBuilder(dataSourceNames: Seq[String],
       }
     } catch {
       case e: Throwable =>
-        error(s"generate rule plan ${name} fails: ${e.getMessage}")
+        error(s"generate rule plan ${name} fails: ${e.getMessage}", e)
         Nil
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
@@ -46,7 +46,7 @@ case class DataFrameOpsTransformStep(name: String,
       true
     } catch {
       case e: Throwable =>
-        error(s"run data frame ops [ ${rule} ] error: ${e.getMessage}")
+        error(s"run data frame ops [ ${rule} ] error: ${e.getMessage}", e)
         false
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
@@ -38,7 +38,7 @@ case class SparkSqlTransformStep(name: String,
       true
     } catch {
       case e: Throwable =>
-        error(s"run spark sql [ ${rule} ] error: ${e.getMessage}")
+        error(s"run spark sql [ ${rule} ] error: ${e.getMessage}", e)
         false
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/DataSourceUpdateWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/DataSourceUpdateWriteStep.scala
@@ -51,7 +51,7 @@ case class DataSourceUpdateWriteStep(dsName: String,
       Some(df)
     } catch {
       case e: Throwable =>
-        error(s"get data frame ${name} fails")
+        error(s"get data frame ${name} fails", e)
         None
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricFlushStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricFlushStep.scala
@@ -37,7 +37,7 @@ case class MetricFlushStep() extends WriteStep {
         true
       } catch {
         case e: Throwable =>
-          error(s"flush metrics error: ${e.getMessage}")
+          error(s"flush metrics error: ${e.getMessage}", e)
           false
       }
       ret && pr

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
@@ -89,7 +89,7 @@ case class MetricWriteStep(name: String,
       } else Nil
     } catch {
       case e: Throwable =>
-        error(s"get metric ${name} fails")
+        error(s"get metric ${name} fails", e)
         Nil
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/RecordWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/RecordWriteStep.scala
@@ -80,7 +80,7 @@ case class RecordWriteStep(name: String,
       Some(df)
     } catch {
       case e: Throwable =>
-        error(s"get data frame ${name} fails")
+        error(s"get data frame ${name} fails", e)
         None
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/utils/FSUtil.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/utils/FSUtil.scala
@@ -43,7 +43,7 @@ object FSUtil extends Loggable {
               FileSystem.get(uri, getConfiguration)
             } catch {
               case e: Throwable =>
-                error(s"get file system error: ${e.getMessage}")
+                error(s"get file system error: ${e.getMessage}", e)
                 throw e
             }
             fsMap += (uri.getScheme -> fs)

--- a/measure/src/main/scala/org/apache/griffin/measure/utils/HdfsUtil.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/utils/HdfsUtil.scala
@@ -87,7 +87,7 @@ object HdfsUtil extends Loggable {
       implicit val path = new Path(dirPath)
       if (getFS.exists(path)) getFS.delete(path, true)
     } catch {
-      case e: Throwable => error(s"delete path [${dirPath}] error: ${e.getMessage}")
+      case e: Throwable => error(s"delete path [${dirPath}] error: ${e.getMessage}", e)
     }
   }
 
@@ -110,7 +110,7 @@ object HdfsUtil extends Loggable {
         }
       } catch {
         case e: Throwable =>
-          warn(s"list path [${dirPath}] warn: ${e.getMessage}")
+          warn(s"list path [${dirPath}] warn: ${e.getMessage}", e)
           Nil
       }
     } else Nil


### PR DESCRIPTION
Sometimes error messages are not descriptive enough and do not allow
to pinpoint exact issue. Exception stack traces should make it easier
to troubleshoot issues.