### PR TITLE
[GRIFFIN-213] Custom connector support

### DIFF
--- a/griffin-doc/deploy/deploy-guide.md
+++ b/griffin-doc/deploy/deploy-guide.md
@@ -164,6 +164,8 @@ You should also modify some configurations of Apache Griffin for your environmen
 		"spark.yarn.dist.files": "hdfs:///<path to>/hive-site.xml"
 	 },
 	  "files": [
+	  ],
+	  "jars": [
 	  ]
 	}
 

--- a/griffin-doc/measure/measure-configuration-guide.md
+++ b/griffin-doc/measure/measure-configuration-guide.md
@@ -188,7 +188,7 @@ Above lists DQ job configure parameters.
 - **sinks**: Whitelisted sink types for this job. Note: no sinks will be used, if empty or omitted. 
 
 ### <a name="data-connector"></a>Data Connector
-- **type**: Data connector type, "AVRO", "HIVE", "TEXT-DIR" for batch mode, "KAFKA" for streaming mode.
+- **type**: Data connector type: "AVRO", "HIVE", "TEXT-DIR", "CUSTOM" for batch mode; "KAFKA", "CUSTOM" for streaming mode.
 - **version**: Version string of data connector type.
 - **config**: Configure parameters of each data connector type.
 	+ avro data connector
@@ -204,6 +204,14 @@ Above lists DQ job configure parameters.
 		* data.dir.depth: integer, depth of data directories, 0 as default.
 		* success.file: success file name, 
 		* done.file: 
+	+ custom connector
+	    * class: class name for user-provided data connector implementation. For Batch
+	    it should be implementing BatchDataConnector trait and have static method with signature
+	    ```def apply(ctx: BatchDataConnectorContext): BatchDataConnector```. 
+	    For Streaming, it should be implementing StreamingDataConnector and have static method
+	    ```def apply(ctx: StreamingDataConnectorContext): StreamingDataConnector```. User-provided
+	    data connector should be present in Spark job's class path, by providing custom jar as -jar parameter
+	    to spark-submit or by adding to "jars" list in sparkProperties.json.  
 
 ### <a name="rule"></a>Rule
 - **dsl.type**: Rule dsl type, "spark-sql", "df-ops" and "griffin-dsl".

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/DataConnectorFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/DataConnectorFactory.scala
@@ -103,7 +103,7 @@ object DataConnectorFactory extends Loggable {
       val meth = cls.getDeclaredMethod("apply", classOf[StreamingDataConnectorContext])
       meth.invoke(null, ctx).asInstanceOf[StreamingDataConnector]
     } else {
-      throw new ClassCastException("")
+      throw new ClassCastException(s"$className should extend BatchDataConnector or StreamingDataConnector")
     }
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/BatchDataConnectorContext.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/BatchDataConnectorContext.scala
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package org.apache.griffin.measure.datasource.connector.batch
+
+import org.apache.spark.sql.SparkSession
+
+import org.apache.griffin.measure.configuration.dqdefinition.DataConnectorParam
+import org.apache.griffin.measure.datasource.TimestampStorage
+
+case class BatchDataConnectorContext(@transient sparkSession: SparkSession,
+                                     dcParam: DataConnectorParam,
+                                     timestampStorage: TimestampStorage)

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/streaming/StreamingDataConnectorContext.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/streaming/StreamingDataConnectorContext.scala
@@ -1,0 +1,32 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package org.apache.griffin.measure.datasource.connector.streaming
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.streaming.StreamingContext
+
+import org.apache.griffin.measure.configuration.dqdefinition.DataConnectorParam
+import org.apache.griffin.measure.datasource.TimestampStorage
+import org.apache.griffin.measure.datasource.cache.StreamingCacheClient
+
+case class StreamingDataConnectorContext(@transient sparkSession: SparkSession,
+                                         @transient ssc: StreamingContext,
+                                         dcParam: DataConnectorParam,
+                                         timestampStorage: TimestampStorage,
+                                         streamingCacheClientOpt: Option[StreamingCacheClient])

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/DataConnectorFactorySpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/DataConnectorFactorySpec.scala
@@ -1,0 +1,90 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package org.apache.griffin.measure.configuration.dqdefinition.reader
+
+import scala.util.Try
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.streaming.dstream.InputDStream
+import org.scalatest.FlatSpec
+
+import org.apache.griffin.measure.configuration.dqdefinition.DataConnectorParam
+import org.apache.griffin.measure.context.TimeRange
+import org.apache.griffin.measure.datasource.TimestampStorage
+import org.apache.griffin.measure.datasource.cache.StreamingCacheClient
+import org.apache.griffin.measure.datasource.connector.DataConnectorFactory
+import org.apache.griffin.measure.datasource.connector.batch.{BatchDataConnector, BatchDataConnectorContext}
+import org.apache.griffin.measure.datasource.connector.streaming.{StreamingDataConnector, StreamingDataConnectorContext}
+
+case class ExampleBatchDataConnector(ctx: BatchDataConnectorContext) extends BatchDataConnector {
+  override val sparkSession: SparkSession = ctx.sparkSession
+  override val dcParam: DataConnectorParam = ctx.dcParam
+  override val timestampStorage: TimestampStorage = ctx.timestampStorage
+
+  override def data(ms: Long): (Option[DataFrame], TimeRange) = (None, TimeRange(ms))
+}
+
+
+case class ExampleStreamingDataConnector(ctx: StreamingDataConnectorContext) extends StreamingDataConnector {
+  override type K = Unit
+  override type V = Unit
+  override type OUT = Unit
+
+  override protected def stream(): Try[InputDStream[this.OUT]] = null
+
+  override def transform(rdd: RDD[this.OUT]): Option[DataFrame] = None
+
+  override val streamingCacheClientOpt: Option[StreamingCacheClient] = ctx.streamingCacheClientOpt
+  override val sparkSession: SparkSession = ctx.sparkSession
+  override val dcParam: DataConnectorParam = ctx.dcParam
+  override val timestampStorage: TimestampStorage = ctx.timestampStorage
+
+  override def init(): Unit = ()
+}
+
+
+class DataConnectorFactorySpec extends FlatSpec {
+
+  "DataConnectorFactory" should "be able to create custom batch connector" in {
+    val param = DataConnectorParam(
+      "CUSTOM", null, null,
+      Map("class" -> classOf[ExampleBatchDataConnector].getCanonicalName), Nil)
+    // apparently Scalamock can not mock classes without empty-paren constructor, providing nulls
+    val res = DataConnectorFactory.getDataConnector(
+      null, null, param, null, None)
+    assert(res.get != null)
+    assert(res.isSuccess)
+    assert(res.get.isInstanceOf[ExampleBatchDataConnector])
+    assert(res.get.data(42)._2.begin == 42)
+  }
+
+  "DataConnectorFactory" should "be able to create custom streaming connector" in {
+    val param = DataConnectorParam(
+      "CUSTOM", null, null,
+      Map("class" -> classOf[ExampleStreamingDataConnector].getCanonicalName), Nil)
+    // apparently Scalamock can not mock classes without empty-paren constructor, providing nulls
+    val res = DataConnectorFactory.getDataConnector(
+      null, null, param, null, None)
+    assert(res.isSuccess)
+    assert(res.get.isInstanceOf[ExampleStreamingDataConnector])
+    assert(res.get.data(0)._2 == TimeRange.emptyTimeRange)
+  }
+
+}

--- a/service/src/main/java/org/apache/griffin/core/measure/entity/DataConnector.java
+++ b/service/src/main/java/org/apache/griffin/core/measure/entity/DataConnector.java
@@ -62,7 +62,8 @@ public class DataConnector extends AbstractAuditableEntity {
          */
         HIVE,
         KAFKA,
-        AVRO
+        AVRO,
+        CUSTOM
     }
 
     @NotNull


### PR DESCRIPTION
Provide ability to extend batch and streaming data integrations
with custom user-provided connectors. Introduces new data connector
type, `CUSTOM`, parameterized with `class` property. Also adds support
for custom data connector enum on service side.